### PR TITLE
Implement basic login with frontend form

### DIFF
--- a/frontend-issue-tracker/src/App.tsx
+++ b/frontend-issue-tracker/src/App.tsx
@@ -7,6 +7,7 @@ import { IssueDetailsView } from "./components/IssueDetailsView";
 import type { Issue, ResolutionStatus as StatusEnum } from "./types"; // Renamed to avoid conflict
 import { ResolutionStatus, statusDisplayNames } from "./types"; // Keep for enum values, import statusDisplayNames
 import { PlusIcon } from "./components/icons/PlusIcon";
+import { LoginForm } from "./components/LoginForm";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -20,6 +21,12 @@ export type IssueFormData = {
 };
 
 const App: React.FC = () => {
+  const [authToken, setAuthToken] = useState<string | null>(() =>
+    localStorage.getItem('authToken')
+  );
+  const [username, setUsername] = useState<string | null>(() =>
+    localStorage.getItem('username')
+  );
   const [issues, setIssues] = useState<Issue[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -35,6 +42,23 @@ const App: React.FC = () => {
   const [showViewIssueModal, setShowViewIssueModal] = useState(false);
   const [selectedIssueForView, setSelectedIssueForView] =
     useState<Issue | null>(null);
+
+  // Persist auth info
+  useEffect(() => {
+    if (authToken) {
+      localStorage.setItem('authToken', authToken);
+    } else {
+      localStorage.removeItem('authToken');
+    }
+  }, [authToken]);
+
+  useEffect(() => {
+    if (username) {
+      localStorage.setItem('username', username);
+    } else {
+      localStorage.removeItem('username');
+    }
+  }, [username]);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);
@@ -121,6 +145,16 @@ const App: React.FC = () => {
   useEffect(() => {
     setCurrentPage(1);
   }, [searchTerm, statusFilter, assigneeFilter, issues.length]);
+
+  const handleLogin = useCallback((token: string, user: string) => {
+    setAuthToken(token);
+    setUsername(user);
+  }, []);
+
+  const handleLogout = useCallback(() => {
+    setAuthToken(null);
+    setUsername(null);
+  }, []);
 
   const handleAddIssue = useCallback(
     async (formData: IssueFormData) => {
@@ -313,6 +347,10 @@ const App: React.FC = () => {
     currentPage * ITEMS_PER_PAGE
   );
 
+  if (!authToken) {
+    return <LoginForm onLogin={handleLogin} />;
+  }
+
   if (isLoading && issues.length === 0) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-slate-100">
@@ -330,10 +368,21 @@ const App: React.FC = () => {
       <div className="max-w-screen-xl mx-auto">
         {" "}
         {/* Increased max-width */}
-        <header className="mb-10 text-center">
+        <header className="mb-10 flex flex-col items-center gap-2">
           <h1 className="text-4xl font-extrabold text-slate-800 sm:text-5xl">
             웹 이슈 트래커
           </h1>
+          {username && (
+            <div className="flex items-center gap-4 mt-2">
+              <span className="text-slate-600">{username}님</span>
+              <button
+                onClick={handleLogout}
+                className="px-3 py-1 text-sm text-white bg-indigo-600 rounded hover:bg-indigo-700"
+              >
+                로그아웃
+              </button>
+            </div>
+          )}
         </header>
         {error && (
           <div

--- a/frontend-issue-tracker/src/components/LoginForm.tsx
+++ b/frontend-issue-tracker/src/components/LoginForm.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+
+interface LoginFormProps {
+  onLogin: (token: string, username: string) => void;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({ onLogin }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      });
+      if (!res.ok) {
+        throw new Error('로그인에 실패했습니다.');
+      }
+      const data = await res.json();
+      onLogin(data.token, data.username);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="max-w-sm mx-auto mt-20 bg-white p-6 shadow rounded"
+    >
+      <h2 className="text-xl font-semibold mb-4 text-slate-700">로그인</h2>
+      {error && <div className="mb-4 text-red-500">{error}</div>}
+      <div className="mb-4">
+        <label className="block mb-1 text-sm font-medium text-slate-700">
+          아이디
+        </label>
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block mb-1 text-sm font-medium text-slate-700">
+          비밀번호
+        </label>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border rounded px-3 py-2"
+        />
+      </div>
+      <button
+        type="submit"
+        className="w-full bg-indigo-600 text-white py-2 rounded hover:bg-indigo-700"
+      >
+        로그인
+      </button>
+    </form>
+  );
+};
+

--- a/server.js
+++ b/server.js
@@ -12,6 +12,10 @@ const app = express();
 const port = process.env.PORT || 3000;
 const ISSUES_FILE_PATH = path.join(__dirname, 'issues.json');
 
+// Simple credentials for demonstration login
+const ADMIN_USERNAME = process.env.ADMIN_USERNAME || 'admin';
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
+
 // 초기 이슈 상태 (types.ts의 ResolutionStatus.OPEN에 해당)
 const INITIAL_ISSUE_STATUS = "OPEN";
 
@@ -54,6 +58,16 @@ async function writeIssuesToFile(issues) {
 }
 
 app.use(express.json()); // JSON 요청 본문 파싱을 위한 미들웨어
+
+// Simple login endpoint for demonstration
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (username === ADMIN_USERNAME && password === ADMIN_PASSWORD) {
+    // In a real application you'd issue a real token here
+    return res.json({ token: 'mock-token', username });
+  }
+  return res.status(401).json({ message: 'Invalid credentials' });
+});
 
 // API Routes
 // GET all issues


### PR DESCRIPTION
## Summary
- add simple login endpoint on the server
- create LoginForm React component
- gate App with login and persist token
- show current user and logout button

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a11b799d8832e900bcf6540165501